### PR TITLE
docs: correctly spell "privilege"

### DIFF
--- a/scripts/linux/energi3-linux-installer.sh
+++ b/scripts/linux/energi3-linux-installer.sh
@@ -108,7 +108,7 @@ _check_runas () {
 
   # Who is running the script
   # If root no sudo required
-  # If user has sudo privilidges, run sudo when necessary
+  # If user has sudo privileges, run sudo when necessary
 
   RUNAS=`whoami`
   
@@ -122,7 +122,7 @@ _check_runas () {
       SUDO='sudo'
     else
       echo "User ${RUNAS} does not have sudo permissions."
-      echo "Run ${BLUE}sudo ls -l${NC} to set permissions if you know the user ${RUNAS} has sudo previlidges"
+      echo "Run ${BLUE}sudo ls -l${NC} to set permissions if you know the user ${RUNAS} has sudo privileges"
       echo "and then rerun the script"
       echo "Exiting script..."
       sleep 3
@@ -205,7 +205,7 @@ _add_nrgstaker () {
 
 _check_install () {
 
-  # Check if run as root or user has sudo privilidges
+  # Check if run as root or user has sudo privileges
   
   _check_runas
   

--- a/scripts/linux/energi3-rpi-installer.sh
+++ b/scripts/linux/energi3-rpi-installer.sh
@@ -129,7 +129,7 @@ _check_runas () {
 
   # Who is running the script
   # If root no sudo required
-  # If user has sudo privilidges, run sudo when necessary
+  # If user has sudo privileges, run sudo when necessary
 
   RUNAS=`whoami`
   
@@ -143,7 +143,7 @@ _check_runas () {
       SUDO='sudo'
     else
       echo "User ${RUNAS} does not have sudo permissions."
-      echo "Run ${BLUE}sudo ls -l${NC} to set permissions if you know the user ${RUNAS} has sudo previlidges"
+      echo "Run ${BLUE}sudo ls -l${NC} to set permissions if you know the user ${RUNAS} has sudo privileges"
       echo "and then rerun the script"
       echo "Exiting script..."
       sleep 3
@@ -241,7 +241,7 @@ _add_nrgstaker () {
 
 _check_install () {
 
-  # Check if run as root or user has sudo privilidges
+  # Check if run as root or user has sudo privileges
   
   _check_runas
   

--- a/scripts/linux/nodemon.sh
+++ b/scripts/linux/nodemon.sh
@@ -98,7 +98,7 @@ NODEMONVER=1.1.1
       SUDO='sudo'
     else
       echo "User ${USRNAME} does not have sudo permissions."
-      echo "Run ${BLUE}sudo ls -l${NC} to set permissions if you know the user ${USRNAME} has sudo previlidges"
+      echo "Run ${BLUE}sudo ls -l${NC} to set permissions if you know the user ${USRNAME} has sudo privileges"
       echo "and then rerun the script"
       echo "Exiting script..."
       sleep 3

--- a/scripts/macos/energi3-macos-installer.sh
+++ b/scripts/macos/energi3-macos-installer.sh
@@ -120,7 +120,7 @@ _check_runas () {
 
   # Who is running the script
   # If root no sudo required
-  # If user has sudo privilidges, run sudo when necessary
+  # If user has sudo privileges, run sudo when necessary
 
   RUNAS=`whoami`
   
@@ -134,7 +134,7 @@ _check_runas () {
       SUDO='sudo'
     else
       echo "User ${RUNAS} does not have sudo permissions."
-      echo "Run ${BLUE}sudo ls -l${NC} to set permissions if you know the user ${RUNAS} has sudo previlidges"
+      echo "Run ${BLUE}sudo ls -l${NC} to set permissions if you know the user ${RUNAS} has sudo privileges"
       echo "and then rerun the script"
       echo "Exiting script..."
       sleep 3


### PR DESCRIPTION
As I was playing around with the installer, I noticed "privilege" was misspelled in a couple of places :smiley: