### PR TITLE
docs: fix prompt message for Discord Webhook URLs

### DIFF
--- a/scripts/linux/nodemon.sh
+++ b/scripts/linux/nodemon.sh
@@ -718,7 +718,7 @@ PAYLOAD
   echo -n ' -> text channels, general, click gear to "edit channel" -> Left side SELECT Webhooks'
   echo -n ' -> Create Webhook -> Copy webhook url -> save'
   echo
-  echo "This webhook will be used for ${TEXT_A} Messages."
+  echo "This webhook will be used for error messages."
   echo 'You can reuse the same webhook url if you want all alerts and information'
   echo 'pings in the same channel.'
 


### PR DESCRIPTION
Previously, the prompt message used the non-existent `TEXT_A` variable (which is defined in a different function), resulting in the message:
`This webhook will be used for ​ Messages.`

This commit replaces the non-existent variable with a hard-coded value (`error`), resulting in the meaage:
`This webhook will be used for error messages.`