### PR TITLE
core node repo changed to go-energi

### DIFF
--- a/scripts/linux/energi-linux-installer.sh
+++ b/scripts/linux/energi-linux-installer.sh
@@ -30,6 +30,7 @@
 #   1.3.14 20220525  ZA Check if GIT_VERSION_TAG is null
 #   1.3.15 20230710  ZA Fix systemctl enable energi3
 #   1.3.16 20230817  ZA Get IP4 Address
+#   1.3.17 20230903  ZA Repo changed to go-energi
 #
 : '
 # Run the script to get started:
@@ -62,7 +63,7 @@ fi
 export DEBIAN_FRONTEND=noninteractive 
 
 # Locations of Repositories and Guide
-export API_URL=${API_URL:-"https://api.github.com/repos/energicryptocurrency/energi/releases/latest"}
+export API_URL=${API_URL:-"https://api.github.com/repos/energicryptocurrency/go-energi/releases/latest"}
 # Production
 export BASE_URL=${BASE_URL:-"raw.githubusercontent.com/energicryptocurrency/energi3-provisioning/master/scripts"}
 #==> For testing set environment variable

--- a/scripts/linux/nodemon.sh
+++ b/scripts/linux/nodemon.sh
@@ -26,9 +26,10 @@
 #   1.3.0  20210208  ZAlam Update USRNAME & DATADIR; support all versions
 #   1.3.1  20211208  ZAlam Energi Core Node repo change
 #   1.3.5  20210101  ZAlam Exclude TTY executions & use correct ${ENERGI_EXEC} binary
+#   1.3.6  20230903  ZAlam Repo changed to go-energi
 #
 # Set script version
-NODEMONVER=1.3.5
+NODEMONVER=1.3.6
 
  : '
 # Run this file
@@ -71,7 +72,7 @@ NODEMONVER=1.3.5
  DISCORD_TITLE_LIMIT=266
  
  # NRG Parameters
- GITAPI_URL="https://api.github.com/repos/energicryptocurrency/energi/releases/latest"
+ GITAPI_URL="https://api.github.com/repos/energicryptocurrency/go-energi/releases/latest"
  
  # Set variables
  MNTOTALNRG=0


### PR DESCRIPTION
The core node repo has been changed from `energi` to `go-energi`